### PR TITLE
Removed South dependency, added Django migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 /dist
 *.swp
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
 
 install:
   - pip install coveralls

--- a/dj_elastictranscoder/migrations/0001_initial.py
+++ b/dj_elastictranscoder/migrations/0001_initial.py
@@ -1,49 +1,26 @@
 # -*- coding: utf-8 -*-
-from south.utils import datetime_utils as datetime
-from south.db import db
-from south.v2 import SchemaMigration
-from django.db import models
+from __future__ import unicode_literals
+
+from django.db import models, migrations
 
 
-class Migration(SchemaMigration):
+class Migration(migrations.Migration):
 
-    def forwards(self, orm):
-        # Adding model 'EncodeJob'
-        db.create_table(u'dj_elastictranscoder_encodejob', (
-            ('id', self.gf('django.db.models.fields.CharField')(max_length=100, primary_key=True)),
-            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
-            ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
-            ('state', self.gf('django.db.models.fields.PositiveIntegerField')(default=0, db_index=True)),
-            ('message', self.gf('django.db.models.fields.TextField')()),
-            ('created_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
-            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
-        ))
-        db.send_create_signal(u'dj_elastictranscoder', ['EncodeJob'])
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
 
-
-    def backwards(self, orm):
-        # Deleting model 'EncodeJob'
-        db.delete_table(u'dj_elastictranscoder_encodejob')
-
-
-    models = {
-        u'contenttypes.contenttype': {
-            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
-            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
-        },
-        u'dj_elastictranscoder.encodejob': {
-            'Meta': {'object_name': 'EncodeJob'},
-            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
-            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
-            'id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
-            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
-            'message': ('django.db.models.fields.TextField', [], {}),
-            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
-            'state': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
-        }
-    }
-
-    complete_apps = ['dj_elastictranscoder']
+    operations = [
+        migrations.CreateModel(
+            name='EncodeJob',
+            fields=[
+                ('id', models.CharField(max_length=100, primary_key=True, serialize=False)),
+                ('object_id', models.PositiveIntegerField()),
+                ('state', models.PositiveIntegerField(default=0, db_index=True, choices=[(0, 'Submitted'), (1, 'Progressing'), (2, 'Error'), (3, 'Warning'), (4, 'Complete')])),
+                ('message', models.TextField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('last_modified', models.DateTimeField(auto_now=True)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+            ],
+        ),
+    ]

--- a/dj_elastictranscoder/south_migrations/0001_initial.py
+++ b/dj_elastictranscoder/south_migrations/0001_initial.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'EncodeJob'
+        db.create_table(u'dj_elastictranscoder_encodejob', (
+            ('id', self.gf('django.db.models.fields.CharField')(max_length=100, primary_key=True)),
+            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
+            ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
+            ('state', self.gf('django.db.models.fields.PositiveIntegerField')(default=0, db_index=True)),
+            ('message', self.gf('django.db.models.fields.TextField')()),
+            ('created_at', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('last_modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+        ))
+        db.send_create_signal(u'dj_elastictranscoder', ['EncodeJob'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'EncodeJob'
+        db.delete_table(u'dj_elastictranscoder_encodejob')
+
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'dj_elastictranscoder.encodejob': {
+            'Meta': {'object_name': 'EncodeJob'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'state': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['dj_elastictranscoder']

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires = [
+    install_requires=[
         "django >= 1.4",
         "boto >= 2.5",
-        "South >= 0.8",
     ],
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This should make the library compatible with Django 1.7 / 1.8.  Currently seeing this error with 1.8:

``` python
There is no South database module 'south.db.postgresql_psycopg2' for your database. Please either choose a supported database, check for SOUTH_DATABASE_ADAPTER[S] settings, or remove South from INSTALLED_APPS.
```
