### PR TITLE
Django 1.7+ compatibility

### DIFF
--- a/dj_elastictranscoder/migrations/0001_initial.py
+++ b/dj_elastictranscoder/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [

--- a/dj_elastictranscoder/tests.py
+++ b/dj_elastictranscoder/tests.py
@@ -3,7 +3,7 @@ import json
 
 from django.test import TestCase
 from django.dispatch import receiver
-from django.db import models
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 
 from .models import EncodeJob
@@ -14,17 +14,14 @@ from .signals import (
 )
 
 
-
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 FIXTURE_DIRS = os.path.join(PROJECT_ROOT, 'fixtures')
 
 
-class Item(models.Model):
-    name = models.CharField(max_length=100)
-
 # ======================
 # define signal receiver
 # ======================
+
 
 @receiver(transcode_onprogress)
 def encode_onprogress(sender, message, **kwargs):
@@ -54,8 +51,8 @@ class SNSNotificationTest(TestCase):
     urls = 'dj_elastictranscoder.urls'
 
     def setUp(self):
-        item = Item.objects.create(name='Hello')
-        content_type = ContentType.objects.get_for_model(Item)
+        item = User.objects.create(username='Hello')
+        content_type = ContentType.objects.get_for_model(User)
         self.job_id = '1396802241671-jkmme8'
 
         self.job = EncodeJob.objects.create(id=self.job_id, content_type=content_type, object_id=item.id)
@@ -105,9 +102,8 @@ class SignalTest(TestCase):
         """
 
         # assume an encode job was submitted
-        item = Item.objects.create(name='Hello')
-
-        ctype = ContentType.objects.get_for_model(item)
+        item = User.objects.create(username='Hello')
+        ctype = ContentType.objects.get_for_model(User)
 
         job = EncodeJob()
         job.id = '1396802241671-jkmme8'
@@ -139,9 +135,8 @@ class SignalTest(TestCase):
         """
 
         # assume an encode job was submitted
-        item = Item.objects.create(name='Hello')
-
-        ctype = ContentType.objects.get_for_model(item)
+        item = User.objects.create(username='Hello')
+        ctype = ContentType.objects.get_for_model(User)
 
         job = EncodeJob()
         job.id = '1396802241671-jkmme8'
@@ -173,9 +168,8 @@ class SignalTest(TestCase):
         """
 
         # assume an encode job was submitted
-        item = Item.objects.create(name='Hello')
-
-        ctype = ContentType.objects.get_for_model(item)
+        item = User.objects.create(username='Hello')
+        ctype = ContentType.objects.get_for_model(User)
 
         job = EncodeJob()
         job.id = '1396802241671-jkmme8'

--- a/runtests.py
+++ b/runtests.py
@@ -3,11 +3,12 @@
 import sys
 from os.path import dirname, abspath
 
+import django
 from django.conf import settings
 
 
 settings.configure(
-    DATABASES = {
+    DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': ':memory:'
@@ -26,6 +27,9 @@ settings.configure(
     ROOT_URLCONF='',
 )
 
+
+if django.VERSION >= (1, 7):
+    django.setup()
 
 
 def runtests(**test_args):


### PR DESCRIPTION
- updated tests to use built-in `User` model instead of the tests-only `Item` model
- added a call to `django.setup()` for Django 1.7+
- made migration depend on contenttypes initial instead of 0002 (which first appeared in Django 1.8 and is not needed as a dependency for this migration)
